### PR TITLE
Add 64 bit network order functions

### DIFF
--- a/include/vigor.h
+++ b/include/vigor.h
@@ -44,6 +44,13 @@
 #include <pthread.h>
 #include <arpa/inet.h> /* so callers get AF_* constants */
 
+#ifndef htonll
+#define htonll(x) ((1==htonl(1)) ? (x) : ((uint64_t)htonl((x) & 0xFFFFFFFF) << 32) | htonl((x) >> 32))
+#endif
+#ifndef ntohll
+#define ntohll(x) ((1==ntohl(1)) ? (x) : ((uint64_t)ntohl((x) & 0xFFFFFFFF) << 32) | ntohl((x) >> 32))
+#endif
+
 #define vmalloc(l)   mem_vmalloc(    (l), __func__, __FILE__, __LINE__)
 #define vcalloc(n,l) mem_vmalloc((n)*(l), __func__, __FILE__, __LINE__)
 void* mem_vmalloc(size_t, const char*, const char*, unsigned int);


### PR DESCRIPTION
To support more networking software, having 64 bit network order
functions to convert to, and from.

These functions are defined as one line macros, that support little
and big endianness. Additionally, if the preprocessor detects
functions in this namespace we attempt to not overwrite them.

This would close #13
